### PR TITLE
Fix BigFloat version of tau

### DIFF
--- a/src/Tau.jl
+++ b/src/Tau.jl
@@ -8,7 +8,7 @@ macro math_const(sym, val, def)
 
     bigconvert = quote
       # Long version of Tau isn't defined in MPFR library so it's defined manually here:
-        Base.convert(::Type{BigFloat}, ::MathConst{:τ}) = BigFloat(6.283185307179586476925286766559005768394338798750211641949889184615632812572417997256069650684234135964296173026564613294187689219101164463450718816256)
+        Base.convert(::Type{BigFloat}, ::MathConst{:τ}) = BigFloat("6.283185307179586476925286766559005768394338798750211641949889184615632812572417997256069650684234135964296173026564613294187689219101164463450718816256")
         big(x::MathConst{:τ}) = Base.convert(BigFloat, τ)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,6 @@ using Base.Test
 @test tau == 2*pi
 @test float32(tau) == 2*float32(pi)
 @test float64(float32(tau)) == float64(2*float32(pi))
+@test big(tau) == 2(big(pi))
 @test isa(tau, MathConst)
 


### PR DESCRIPTION
- Julia was truncating the inline float at 64 bits; using a string allows the full precision
- Also added a test
