### PR TITLE
Test with Travis on Julia 0.5 and 0.6, add 0.6 to Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 


### PR DESCRIPTION
On Travis, "release" is a moving target, not very useful if you want to test on old-stable releases (as Julia 0.5 will be when 0.6 will go out).  With this PR we explicitly require testing on Julia 0.5 and 0.6.