### PR TITLE
Do no use @vectorize_1arg

### DIFF
--- a/src/trig.jl
+++ b/src/trig.jl
@@ -92,8 +92,5 @@ function costau{T}(z::Complex{T})
     end
 end
 
-Base.@vectorize_1arg Number sintau
-Base.@vectorize_1arg Number costau
-
 const sinτ = sintau
 const cosτ = costau


### PR DESCRIPTION
Since we're going to drop support for Julia 0.4 (#13), the calls to `@vectorize_1arg` can be removed.