### PR TITLE
Remove methods such as `sinτ`

### DIFF
--- a/src/Tau.jl
+++ b/src/Tau.jl
@@ -3,20 +3,18 @@ module Tau
 import IrrationalConstants
 
 export tau, τ,
-       sintau, costau, sincostau, cistau, modtau,
-       sinτ, cosτ, sincosτ, cisτ, modτ
+       sintau, costau, sincostau, cistau, modtau
 
 # Definition of τ as irrational constant
 const τ = IrrationalConstants.twoπ
 const tau = τ
 
-const modτ = mod2pi
-const modtau = modτ
+const modtau = mod2pi
 
 # Trigonometric functions
-sinτ(x) = sinpi(2 * x)
-cosτ(x) = cospi(2 * x)
-function sincosτ(x)
+sintau(x) = sinpi(2 * x)
+costau(x) = cospi(2 * x)
+function sincostau(x)
     y = 2 * x
     # sincospi was added in https://github.com/JuliaLang/julia/pull/35816
     @static if VERSION < v"1.6.0-DEV.292"
@@ -25,29 +23,24 @@ function sincosτ(x)
         return sincospi(y)
     end
 end
-cisτ(x::Real) = complex(reverse(sincosτ(x))...)
-function cisτ(z::Complex)
-    sitau, cotau = sincosτ(z)
+cistau(x::Real) = complex(reverse(sincostau(x))...)
+function cistau(z::Complex)
+    sitau, cotau = sincostau(z)
     re_sitau, im_sitau = reim(sitau)
     re_cotau, im_cotau = reim(cotau)
     return complex(re_cotau - im_sitau, im_cotau + re_sitau)
 end
 
 # Optimization for integers
-sinτ(x::Integer) = zero(float(x))
-cosτ(x::Integer) = one(float(x))
-function sincosτ(x::Integer)
+sintau(x::Integer) = zero(float(x))
+costau(x::Integer) = one(float(x))
+function sincostau(x::Integer)
     y = float(x)
     return (zero(y), one(y))
 end
-function cisτ(x::Integer)
+function cistau(x::Integer)
     y = float(x)
     return complex(one(y), zero(y))
 end
-
-const sintau = sinτ
-const costau = cosτ
-const sincostau = sincosτ
-const cistau = cisτ
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,12 +110,6 @@ end
         end
     end
 
-    @testset "aliases" begin
-        @test sinτ === sintau
-        @test cosτ === costau
-        @test sincosτ === sincostau
-        @test cisτ === cistau
-    end
 end
 
 # Adapted from julia/test/mod2pi.jl
@@ -131,5 +125,4 @@ end
 
     # aliases
     @test modtau === mod2pi
-    @test modτ === modtau
 end


### PR DESCRIPTION
This PR fixes https://github.com/JuliaMath/Tau.jl/issues/49.