### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tau"
 uuid = "c544e3c2-d3e5-5802-ac44-44683f340e4a"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"


### PR DESCRIPTION
Just a patch bump to release the [changes since 2.0.0](https://github.com/JuliaMath/Tau.jl/compare/2b2bd4e758dc44a94b37d14c984eba59d3aa6d77...4881d46b084fe33b8466e7b2ee8c0c1d86797370), which include version bumps done by Dependabot in #52, #53 (plus its follow-up fix in #58), #54 and #55, and most importantly, the logo's support for dark mode contributed by @rwnobrega in #56.