### PR TITLE
Add CODECOV_TOKEN to the corresponding GH Action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,3 +35,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The upgrade from the [Codecov GitHub Action](https://github.com/codecov/codecov-action) from v3 to v4 done in #53 required the addition of the `CODECOV_TOKEN` environment variable to actually work — see https://github.com/JuliaMath/Tau.jl/pull/53#issuecomment-2246384406.

I first went into the [Codecov settings for this repo](https://app.codecov.io/github/JuliaMath/Tau.jl/settings) to obtain the token value, but then I realized that this variable is already available as a [secret variable for GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) in the JuliaMath organization level. So the only thing that needs to be done (IIUC) is adding the line to GitHub Actions workflow .yml file specifying that the `codecov-action` should run with access to this secret — which is what this PR does.

