### PR TITLE
Add JuliaHub version badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <div align="center"><img src="tau-2pi.svg" width="300"/></div><br/><br/>
 
+[![version](https://juliahub.com/docs/General/Tau/stable/version.svg)](https://juliahub.com/ui/Packages/General/Tau)
 [![CI](https://github.com/JuliaMath/Tau.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/JuliaMath/Tau.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![codecov](https://img.shields.io/codecov/c/github/JuliaMath/Tau.jl/master.svg?label=coverage)](http://codecov.io/github/JuliaMath/Tau.jl)
 


### PR DESCRIPTION
Since TagBot doesn't seem to be set up correctly and [is not generating tags](https://github.com/JuliaMath/Tau.jl/issues/41#issuecomment-2246591985) based on the released versions (@giordano do you know if this is [still a TagBot issue](https://github.com/JuliaMath/Tau.jl/issues/41#issuecomment-1615992151) rather than merely the repo being misconfigured?), I thought it would be useful to add a version badge to the README to at least provide the version information more prominently.